### PR TITLE
Fix typo s/posoitioning/positioning

### DIFF
--- a/src/pages/centering.njk
+++ b/src/pages/centering.njk
@@ -345,7 +345,7 @@ After absolutely positioning the child from the top 50% and left 50%, which is 5
 
 #### Gotchas
 
-Because we've used absolute posoitioning, there's a chance the content will grow to overflow the parent, even if like in the demo the parent has a `min-width` which typically grows with the content _except_ for absolute children.
+Because we've used absolute positioning, there's a chance the content will grow to overflow the parent, even if like in the demo the parent has a `min-width` which typically grows with the content _except_ for absolute children.
 
 The fix for this is: use grid or flexbox :) Or prepare to create #allthemediaqueries.
 


### PR DESCRIPTION
I randomly visited https://smolcss.dev/ from your newsletter, looked into vertical centering, clicked to https://moderncss.dev/complete-guide-to-centering-in-css/#xy-centering-for-block-elements and found this typo.